### PR TITLE
Add abbility to set Annotations for vvp-operator pods

### DIFF
--- a/charts/vp-k8s-operator/Chart.yaml
+++ b/charts/vp-k8s-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "latest"
 description: A Helm chart for the Ververica Platform K8s Operator
 name: vp-k8s-operator
-version: 0.12.1
+version: 0.13.0

--- a/charts/vp-k8s-operator/README.md
+++ b/charts/vp-k8s-operator/README.md
@@ -4,24 +4,25 @@ A Helm chart for deploying the Ververica Platform Kubernetes Operator.
 
 ## Installing the Chart
 
-| Parameter                    | Description                                           | Default                                            |
-|------------------------------|-------------------------------------------------------|----------------------------------------------------|
-| `rbac.enabled`               | Whether or not to create RBAC resources.              | `true`                                             |
-| `rbacProxy.enabled`          | Whether or not to create an RBAC proxy over `https`.  | `true`                                             |
-| `rbacProxy.logLevel`         | Log level for the proxy.                              | `10`                                               |
-| `rbacProxy.imageRepository`  |                                                       | `gcr.io/kubebuilder/kube-rbac-proxy`               |
-| `rbacProxy.imageTag`         |                                                       | `v0.4.0`                                           |
-| `rbacProxy.imagePullPolicy`  |                                                       | `IfNotPresent`                                     |
-| `rbacProxy.port`             |                                                       | `8443`                                             |
-| `imageRepository`            | Image repository for the Manager                      | `fintechstudios/ververica-platform-k8s-operator`   |
-| `imageTag`                   |                                                       | `latest`                                           |
-| `imagePullPolicy`            |                                                       | `IfNotPresent`                                     |
-| `metricsHost`                | Host for the metrics reporter.                        | `127.0.0.1`                                        |
-| `metricsPort`                | Port for the metrics reporter.                        | `8080`                                             |
-| `metricsMonitorEnabled`      | Whether or not to create a Prometheus ServiceMonitor. | `false`                                            |
-| `certs.enabled`              | Whether or not to create CertManager certs for webhook serving. | `true`                                   |
-| `certs.existingSecret`       | If not creating certs, must specify a secret with pre-existing certs. | `nil`                              |
-| `vvpUrl`                     | URL for the Ververica Platform.                       | `http://ververica-platform`                        |
-| `vvpEdition`                 | Ververica Platform Edition. Either `community` or `enterprise`. | `enterprise`                             |
-| `extraArgs`                  | Extra CLI args to pass to the controller manager.                | `[]`                                       |
-| `resources`                  | Resource specs for the manager deployment.             | `{ limits: { cpu: 100m, memory: 30Mi }, rqeuests: { cpu: 100m, memory 20Mi } }` |
+| Parameter                   | Description                                                           | Default                                                                         |
+| --------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `rbac.enabled`              | Whether or not to create RBAC resources.                              | `true`                                                                          |
+| `rbacProxy.enabled`         | Whether or not to create an RBAC proxy over `https`.                  | `true`                                                                          |
+| `rbacProxy.logLevel`        | Log level for the proxy.                                              | `10`                                                                            |
+| `rbacProxy.imageRepository` |                                                                       | `gcr.io/kubebuilder/kube-rbac-proxy`                                            |
+| `rbacProxy.imageTag`        |                                                                       | `v0.4.0`                                                                        |
+| `rbacProxy.imagePullPolicy` |                                                                       | `IfNotPresent`                                                                  |
+| `rbacProxy.port`            |                                                                       | `8443`                                                                          |
+| `imageRepository`           | Image repository for the Manager                                      | `fintechstudios/ververica-platform-k8s-operator`                                |
+| `imageTag`                  |                                                                       | `latest`                                                                        |
+| `imagePullPolicy`           |                                                                       | `IfNotPresent`                                                                  |
+| `metricsHost`               | Host for the metrics reporter.                                        | `127.0.0.1`                                                                     |
+| `metricsPort`               | Port for the metrics reporter.                                        | `8080`                                                                          |
+| `metricsMonitorEnabled`     | Whether or not to create a Prometheus ServiceMonitor.                 | `false`                                                                         |
+| `certs.enabled`             | Whether or not to create CertManager certs for webhook serving.       | `true`                                                                          |
+| `certs.existingSecret`      | If not creating certs, must specify a secret with pre-existing certs. | `nil`                                                                           |
+| `vvpUrl`                    | URL for the Ververica Platform.                                       | `http://ververica-platform`                                                     |
+| `vvpEdition`                | Ververica Platform Edition. Either `community` or `enterprise`.       | `enterprise`                                                                    |
+| `extraArgs`                 | Extra CLI args to pass to the controller manager.                     | `[]`                                                                            |
+| `resources`                 | Resource specs for the manager deployment.                            | `{ limits: { cpu: 100m, memory: 30Mi }, rqeuests: { cpu: 100m, memory 20Mi } }` |
+| `podAnnotations`            | Annotations to be added to the pods (inside deployment).              | `{}`                                                                            |

--- a/charts/vp-k8s-operator/templates/deployment.yaml
+++ b/charts/vp-k8s-operator/templates/deployment.yaml
@@ -17,6 +17,12 @@ spec:
     metadata:
       labels:
         control-plane: {{ template "vp-k8s-operator.name" . }}-controller-manager
+    {{- if .Values.podAnnotations }}
+      annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    {{- end }}
     spec:
       containers:
           {{- if .Values.rbacProxy.enabled }}

--- a/charts/vp-k8s-operator/values.yaml
+++ b/charts/vp-k8s-operator/values.yaml
@@ -48,3 +48,6 @@ resources:
 
 # Extra arguments to pass to the manager
 # extraArgs: []
+
+# Annotations to be added to pods
+podAnnotations: {}


### PR DESCRIPTION
* add `podAnnotations` setting in `values.yaml` with possibility to set Annotations for Ververica operator pods (via Deployment)
* Bump chart minor version
* Update README