### PR TITLE
[ESP-236] Configure livenessProbe for manager container

### DIFF
--- a/charts/vp-k8s-operator/Chart.yaml
+++ b/charts/vp-k8s-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "latest"
 description: A Helm chart for the Ververica Platform K8s Operator
 name: vp-k8s-operator
-version: 0.13.0
+version: 0.14.0

--- a/charts/vp-k8s-operator/README.md
+++ b/charts/vp-k8s-operator/README.md
@@ -24,5 +24,6 @@ A Helm chart for deploying the Ververica Platform Kubernetes Operator.
 | `vvpUrl`                    | URL for the Ververica Platform.                                       | `http://ververica-platform`                                                     |
 | `vvpEdition`                | Ververica Platform Edition. Either `community` or `enterprise`.       | `enterprise`                                                                    |
 | `extraArgs`                 | Extra CLI args to pass to the controller manager.                     | `[]`                                                                            |
-| `resources`                 | Resource specs for the manager deployment.                            | `{ limits: { cpu: 100m, memory: 30Mi }, rqeuests: { cpu: 100m, memory 20Mi } }` |
+| `resources`                 | Resource specs for the manager deployment.                            | `{ limits: { cpu: 100m, memory: 30Mi }, requests: { cpu: 100m, memory 20Mi } }` |
+| `livenessProbe`             | Liveness Probe configuration for manager container.                   | `{}`                                                                            |
 | `podAnnotations`            | Annotations to be added to the pods (inside deployment).              | `{}`                                                                            |

--- a/charts/vp-k8s-operator/templates/deployment.yaml
+++ b/charts/vp-k8s-operator/templates/deployment.yaml
@@ -54,7 +54,9 @@ spec:
               name: webhook-server
               protocol: TCP
           resources:
-            {{ toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs
               name: cert

--- a/charts/vp-k8s-operator/values.yaml
+++ b/charts/vp-k8s-operator/values.yaml
@@ -46,6 +46,17 @@ resources:
     cpu: 100m
     memory: 20Mi
 
+# Liveness Probe (metrics endpoint can be used for that)
+livenessProbe: {}
+# livenessProbe:
+#   httpGet:
+#     path: /metrics
+#     port: 8080
+#   failureThreshold: 3
+#   successThreshold: 1
+#   initialDelaySeconds: 30
+#   periodSeconds: 10
+
 # Extra arguments to pass to the manager
 # extraArgs: []
 


### PR DESCRIPTION
Add `livenessProbe` configuration for `manager` container. 
Since we're missing `healthz` endpoint, `metrics` can be used for that