### PR TITLE
feat: Create and configure custom serviceAccount for pod/deployment

### DIFF
--- a/charts/vp-k8s-operator/Chart.yaml
+++ b/charts/vp-k8s-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "latest"
 description: A Helm chart for the Ververica Platform K8s Operator
 name: vp-k8s-operator
-version: 0.14.0
+version: 0.15.0

--- a/charts/vp-k8s-operator/README.md
+++ b/charts/vp-k8s-operator/README.md
@@ -4,26 +4,29 @@ A Helm chart for deploying the Ververica Platform Kubernetes Operator.
 
 ## Installing the Chart
 
-| Parameter                   | Description                                                           | Default                                                                         |
-| --------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| `rbac.enabled`              | Whether or not to create RBAC resources.                              | `true`                                                                          |
-| `rbacProxy.enabled`         | Whether or not to create an RBAC proxy over `https`.                  | `true`                                                                          |
-| `rbacProxy.logLevel`        | Log level for the proxy.                                              | `10`                                                                            |
-| `rbacProxy.imageRepository` |                                                                       | `gcr.io/kubebuilder/kube-rbac-proxy`                                            |
-| `rbacProxy.imageTag`        |                                                                       | `v0.4.0`                                                                        |
-| `rbacProxy.imagePullPolicy` |                                                                       | `IfNotPresent`                                                                  |
-| `rbacProxy.port`            |                                                                       | `8443`                                                                          |
-| `imageRepository`           | Image repository for the Manager                                      | `fintechstudios/ververica-platform-k8s-operator`                                |
-| `imageTag`                  |                                                                       | `latest`                                                                        |
-| `imagePullPolicy`           |                                                                       | `IfNotPresent`                                                                  |
-| `metricsHost`               | Host for the metrics reporter.                                        | `127.0.0.1`                                                                     |
-| `metricsPort`               | Port for the metrics reporter.                                        | `8080`                                                                          |
-| `metricsMonitorEnabled`     | Whether or not to create a Prometheus ServiceMonitor.                 | `false`                                                                         |
-| `certs.enabled`             | Whether or not to create CertManager certs for webhook serving.       | `true`                                                                          |
-| `certs.existingSecret`      | If not creating certs, must specify a secret with pre-existing certs. | `nil`                                                                           |
-| `vvpUrl`                    | URL for the Ververica Platform.                                       | `http://ververica-platform`                                                     |
-| `vvpEdition`                | Ververica Platform Edition. Either `community` or `enterprise`.       | `enterprise`                                                                    |
-| `extraArgs`                 | Extra CLI args to pass to the controller manager.                     | `[]`                                                                            |
-| `resources`                 | Resource specs for the manager deployment.                            | `{ limits: { cpu: 100m, memory: 30Mi }, requests: { cpu: 100m, memory 20Mi } }` |
-| `livenessProbe`             | Liveness Probe configuration for manager container.                   | `{}`                                                                            |
-| `podAnnotations`            | Annotations to be added to the pods (inside deployment).              | `{}`                                                                            |
+| Parameter                    | Description                                                           | Default                                                                         |
+| ---------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `rbac.enabled`               | Whether or not to create RBAC resources.                              | `true`                                                                          |
+| `rbacProxy.enabled`          | Whether or not to create an RBAC proxy over `https`.                  | `true`                                                                          |
+| `rbacProxy.logLevel`         | Log level for the proxy.                                              | `10`                                                                            |
+| `rbacProxy.imageRepository`  |                                                                       | `gcr.io/kubebuilder/kube-rbac-proxy`                                            |
+| `rbacProxy.imageTag`         |                                                                       | `v0.4.0`                                                                        |
+| `rbacProxy.imagePullPolicy`  |                                                                       | `IfNotPresent`                                                                  |
+| `rbacProxy.port`             |                                                                       | `8443`                                                                          |
+| `serviceAccount.create`      | Whether or not to create k8s serviceAccount                           | `true`                                                                          |
+| `serviceAccount.annotations` | Annotations added to serviceAccount                                   | `{}`                                                                            |
+| `serviceAccount.name`        | Custom name of serviceAccount to create                               | `""`                                                                            |
+| `imageRepository`            | Image repository for the Manager                                      | `fintechstudios/ververica-platform-k8s-operator`                                |
+| `imageTag`                   |                                                                       | `latest`                                                                        |
+| `imagePullPolicy`            |                                                                       | `IfNotPresent`                                                                  |
+| `metricsHost`                | Host for the metrics reporter.                                        | `127.0.0.1`                                                                     |
+| `metricsPort`                | Port for the metrics reporter.                                        | `8080`                                                                          |
+| `metricsMonitorEnabled`      | Whether or not to create a Prometheus ServiceMonitor.                 | `false`                                                                         |
+| `certs.enabled`              | Whether or not to create CertManager certs for webhook serving.       | `true`                                                                          |
+| `certs.existingSecret`       | If not creating certs, must specify a secret with pre-existing certs. | `nil`                                                                           |
+| `vvpUrl`                     | URL for the Ververica Platform.                                       | `http://ververica-platform`                                                     |
+| `vvpEdition`                 | Ververica Platform Edition. Either `community` or `enterprise`.       | `enterprise`                                                                    |
+| `extraArgs`                  | Extra CLI args to pass to the controller manager.                     | `[]`                                                                            |
+| `resources`                  | Resource specs for the manager deployment.                            | `{ limits: { cpu: 100m, memory: 30Mi }, requests: { cpu: 100m, memory 20Mi } }` |
+| `livenessProbe`              | Liveness Probe configuration for manager container.                   | `{}`                                                                            |
+| `podAnnotations`             | Annotations to be added to the pods (inside deployment).              | `{}`                                                                            |

--- a/charts/vp-k8s-operator/templates/_helpers.tpl
+++ b/charts/vp-k8s-operator/templates/_helpers.tpl
@@ -43,3 +43,14 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "vp-k8s-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "vp-k8s-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/vp-k8s-operator/templates/deployment.yaml
+++ b/charts/vp-k8s-operator/templates/deployment.yaml
@@ -24,6 +24,8 @@ spec:
       {{- end }}
     {{- end }}
     spec:
+      serviceAccountName: {{ include "vp-k8s-operator.serviceAccountName" . }}
+      automountServiceAccountToken: true
       containers:
           {{- if .Values.rbacProxy.enabled }}
         - name: kube-rbac-proxy

--- a/charts/vp-k8s-operator/templates/rbac.yaml
+++ b/charts/vp-k8s-operator/templates/rbac.yaml
@@ -152,7 +152,7 @@ roleRef:
   name: {{ template "vp-k8s-operator.name" . }}-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: {{ include "vp-k8s-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -165,7 +165,7 @@ roleRef:
   name: {{ template "vp-k8s-operator.name" . }}-manager-role
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: {{ include "vp-k8s-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -178,6 +178,6 @@ roleRef:
   name: {{ template "vp-k8s-operator.name" . }}-proxy-role
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: {{ include "vp-k8s-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/vp-k8s-operator/templates/serviceaccount.yaml
+++ b/charts/vp-k8s-operator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "vp-k8s-operator.serviceAccountName" . }}
+  labels:
+    {{- include "vp-k8s-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/vp-k8s-operator/values.yaml
+++ b/charts/vp-k8s-operator/values.yaml
@@ -9,6 +9,15 @@ rbacProxy:
   imagePullPolicy: IfNotPresent
   port: 8443
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
 # Metrics
 metricsHost: 127.0.0.1
 metricsPort: 8080


### PR DESCRIPTION
Add configuration for custom k8s `serviceAccount` used by deployment pods (previously `default` SA was used) and binded to needed RBAC Roles.